### PR TITLE
Indicate CPython

### DIFF
--- a/win2016-azure-pipelines.yml
+++ b/win2016-azure-pipelines.yml
@@ -149,7 +149,7 @@ jobs:
       cd $(src.python)
       python -m pip install -U pip
       pip install -U setuptools wheel
-      python setup.py bdist_wheel --python-tag=py$(python.version_major)$(python.version_minor) --plat-name=win-amd64 --dist-dir="$(Build.ArtifactStagingDirectory)"
+      python setup.py bdist_wheel --python-tag=cp$(python.version_major)$(python.version_minor) --plat-name=win-amd64 --dist-dir="$(Build.ArtifactStagingDirectory)"
       cd $(Build.ArtifactStagingDirectory)
       tree /F
     condition: eq( variables['Agent.OS'], 'Windows_NT' )


### PR DESCRIPTION
Instead of using python tag "py3x", let's use "cp3x" as that seems more appropriate.