### PR TITLE
Add GitHub releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,8 @@ See the `tests` folder for code examples used to test the built wheels' function
 - The vcpkg files for oiio at [vcpkg/ports/openimageio](https://github.com/Microsoft/vcpkg/tree/master/ports/openimageio)
 - Get SHA512 of file:
   - macOS: `openssl dgst -sha512 [FILE]`
+- Create release:
+    1. Commit changes: `git commit -am "My changes"`
+    2. Create tag: `git tag [oiio-version]+[yyyymmdd]` (e.g. `2.0.4+20190202`)
+    3. Push tag: `git push origin [oiio-version]+[yyyymmdd]`
+    4. Push changes: `git push`

--- a/macOS-10.13-azure-pipelines.yml
+++ b/macOS-10.13-azure-pipelines.yml
@@ -42,6 +42,12 @@ jobs:
       architecture: 'x64'
       addToPath: true
 
+  # Create $(build.date) variable, to be used for GitHub release
+  - bash: |
+      DATE=`date +%Y%m%d`
+      echo "##vso[task.setvariable variable=build.date]$DATE"
+    displayName: Create build.date variable
+
   # Make setup.py ready by substituting placeholders
   - bash: |
       cd $(src.python)
@@ -139,3 +145,25 @@ jobs:
       pip list
       pytest --verbose
     displayName: Run rudimental test(s)
+
+  # GitHub Release
+  # Create, edit, or discard a GitHub release.
+  # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release?view=azdevops
+  - task: GithubRelease@0
+    inputs:
+      gitHubConnection: 'oiio-python-releases'
+      repositoryName: 'fredrikaverpil/oiio-python'
+      action: 'edit' # Options: create, edit, discard
+      target: '$(build.sourceVersion)' # Required when action == create || action == edit
+      tagSource: 'Git tag' # Required when action == create. Options: auto, manual
+      tag: '$(oiio.version)+$(build.date)' # Required when action == edit || action == discard || tagSource == manual
+      #title: # Optional
+      #releaseNotesSource: 'file' # Optional. Options: file, input
+      #releaseNotesFile: # Optional
+      #releaseNotes: # Optional
+      # assets: '$(build.artifactStagingDirectory)/*' # Optional
+      # assets: '$(Build.ArtifactStagingDirectory)' # Optional
+      assetUploadMode: 'replace' # Optional. Options: delete, replace
+      #isDraft: false # Optional
+      #isPreRelease: false # Optional
+      addChangeLog: false # Optional

--- a/ubuntu16.04-azure-pipelines.yml
+++ b/ubuntu16.04-azure-pipelines.yml
@@ -41,6 +41,12 @@ jobs:
       architecture: 'x64'
       addToPath: true
 
+  # Create $(build.date) variable, to be used for GitHub release
+  - bash: |
+      DATE=`date +%Y%m%d`
+      echo "##vso[task.setvariable variable=build.date]$DATE"
+    displayName: Create build.date variable
+
   # Make setup.py ready by substituting placeholders
   - bash: |
       cd $(src.python)
@@ -147,3 +153,25 @@ jobs:
       pip list
       pytest --verbose
     displayName: Run rudimental test(s)
+
+  # GitHub Release
+  # Create, edit, or discard a GitHub release.
+  # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release?view=azdevops
+  - task: GithubRelease@0
+    inputs:
+      gitHubConnection: 'oiio-python-releases'
+      repositoryName: 'fredrikaverpil/oiio-python'
+      action: 'edit' # Options: create, edit, discard
+      target: '$(build.sourceVersion)' # Required when action == create || action == edit
+      tagSource: 'Git tag' # Required when action == create. Options: auto, manual
+      tag: '$(oiio.version)+$(build.date)' # Required when action == edit || action == discard || tagSource == manual
+      #title: # Optional
+      #releaseNotesSource: 'file' # Optional. Options: file, input
+      #releaseNotesFile: # Optional
+      #releaseNotes: # Optional
+      # assets: '$(build.artifactStagingDirectory)/*' # Optional
+      # assets: '$(Build.ArtifactStagingDirectory)' # Optional
+      assetUploadMode: 'replace' # Optional. Options: delete, replace
+      #isDraft: false # Optional
+      #isPreRelease: false # Optional
+      addChangeLog: false # Optional

--- a/win2016-azure-pipelines.yml
+++ b/win2016-azure-pipelines.yml
@@ -40,6 +40,13 @@ jobs:
       architecture: 'x64'
       addToPath: true
 
+  # Create $(build.date) variable, to be used for GitHub release
+  - powershell: |
+      $Date = Get-Date -format "yyyyMMdd"
+      $DateStr = $Date.ToString()
+      echo "##vso[task.setvariable variable=build.date]$DateStr"
+    displayName: Create build.date variable
+
   # Make setup.py ready by substituting placeholders
   - powershell: |
       cd $(src.python)
@@ -174,3 +181,25 @@ jobs:
       pip list
       pytest --verbose
     displayName: Run rudimental test(s)
+
+  # GitHub Release
+  # Create, edit, or discard a GitHub release.
+  # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release?view=azdevops
+  - task: GithubRelease@0
+    inputs:
+      gitHubConnection: 'oiio-python-releases'
+      repositoryName: 'fredrikaverpil/oiio-python'
+      action: 'edit' # Options: create, edit, discard
+      target: '$(build.sourceVersion)' # Required when action == create || action == edit
+      tagSource: 'Git tag' # Required when action == create. Options: auto, manual
+      tag: '$(oiio.version)+$(build.date)' # Required when action == edit || action == discard || tagSource == manual
+      #title: # Optional
+      #releaseNotesSource: 'file' # Optional. Options: file, input
+      #releaseNotesFile: # Optional
+      #releaseNotes: # Optional
+      # assets: '$(build.artifactStagingDirectory)/*' # Optional
+      # assets: '$(Build.ArtifactStagingDirectory)' # Optional
+      assetUploadMode: 'replace' # Optional. Options: delete, replace
+      #isDraft: false # Optional
+      #isPreRelease: false # Optional
+      addChangeLog: false # Optional


### PR DESCRIPTION
Fix #16 

This will trigger a GitHub release if a tag exists at the commit running in Azure Pipelines. The tag must follow the syntax: `[oiio-version]+[yyyymmdd]` e.g. `2.0.4+20190202`

Example workflow:
-  Commit changes. Then create a tag, push it (to origin) and finally push the changes.