### PR TITLE
Only publish GitHub release for master branch

### DIFF
--- a/macOS-10.13-azure-pipelines.yml
+++ b/macOS-10.13-azure-pipelines.yml
@@ -148,6 +148,7 @@ jobs:
 
   # GitHub Release
   # Create, edit, or discard a GitHub release.
+  # https://github.com/Microsoft/azure-pipelines-tasks/tree/master/Tasks/GitHubReleaseV0
   # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release?view=azdevops
   - task: GithubRelease@0
     inputs:
@@ -156,8 +157,8 @@ jobs:
       action: 'edit' # Options: create, edit, discard
       target: '$(build.sourceVersion)' # Required when action == create || action == edit
       tagSource: 'Git tag' # Required when action == create. Options: auto, manual
-      tag: '$(oiio.version)+$(build.date)' # Required when action == edit || action == discard || tagSource == manual
-      title: '$(oiio.version)+$(build.date)'
+      tag: '$(oiio.version)-$(build.date)' # Required when action == edit || action == discard || tagSource == manual
+      title: '$(oiio.version)-$(build.date)'
       #releaseNotesSource: 'file' # Optional. Options: file, input
       #releaseNotesFile: # Optional
       #releaseNotes: # Optional
@@ -167,3 +168,4 @@ jobs:
       #isDraft: false # Optional
       #isPreRelease: false # Optional
       addChangeLog: false # Optional
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')

--- a/ubuntu16.04-azure-pipelines.yml
+++ b/ubuntu16.04-azure-pipelines.yml
@@ -156,6 +156,7 @@ jobs:
 
   # GitHub Release
   # Create, edit, or discard a GitHub release.
+  # https://github.com/Microsoft/azure-pipelines-tasks/tree/master/Tasks/GitHubReleaseV0
   # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release?view=azdevops
   - task: GithubRelease@0
     inputs:
@@ -164,8 +165,8 @@ jobs:
       action: 'edit' # Options: create, edit, discard
       target: '$(build.sourceVersion)' # Required when action == create || action == edit
       tagSource: 'Git tag' # Required when action == create. Options: auto, manual
-      tag: '$(oiio.version)+$(build.date)' # Required when action == edit || action == discard || tagSource == manual
-      title: '$(oiio.version)+$(build.date)'
+      tag: '$(oiio.version)-$(build.date)' # Required when action == edit || action == discard || tagSource == manual
+      title: '$(oiio.version)-$(build.date)'
       #releaseNotesSource: 'file' # Optional. Options: file, input
       #releaseNotesFile: # Optional
       #releaseNotes: # Optional
@@ -175,3 +176,4 @@ jobs:
       #isDraft: false # Optional
       #isPreRelease: false # Optional
       addChangeLog: false # Optional
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')

--- a/win2016-azure-pipelines.yml
+++ b/win2016-azure-pipelines.yml
@@ -184,6 +184,7 @@ jobs:
 
   # GitHub Release
   # Create, edit, or discard a GitHub release.
+  # https://github.com/Microsoft/azure-pipelines-tasks/tree/master/Tasks/GitHubReleaseV0
   # https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release?view=azdevops
   - task: GithubRelease@0
     inputs:
@@ -192,8 +193,8 @@ jobs:
       action: 'edit' # Options: create, edit, discard
       target: '$(build.sourceVersion)' # Required when action == create || action == edit
       tagSource: 'Git tag' # Required when action == create. Options: auto, manual
-      tag: '$(oiio.version)+$(build.date)' # Required when action == edit || action == discard || tagSource == manual
-      title: '$(oiio.version)+$(build.date)'
+      tag: '$(oiio.version)-$(build.date)' # Required when action == edit || action == discard || tagSource == manual
+      title: '$(oiio.version)-$(build.date)'
       #releaseNotesSource: 'file' # Optional. Options: file, input
       #releaseNotesFile: # Optional
       #releaseNotes: # Optional
@@ -203,3 +204,4 @@ jobs:
       #isDraft: false # Optional
       #isPreRelease: false # Optional
       addChangeLog: false # Optional
+    condition: eq(variables['Build.SourceBranch'], 'refs/heads/master')


### PR DESCRIPTION
I am not sure how it is possible, but a release seems to be created every time a build runs right now. At least, it would be nice to limit this to master branch commits.